### PR TITLE
Mut as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hi Ada, thanks for being premium!
 
 ## Features
 
-* Variables (`let`) and mutation (`mut`)
+* Variables (`let`) and assignment (`x = ...`)
 * Conditionals (`if` / `elseif` / `else`) and loops (`for`)
 * Numbers, strings, booleans, arrays, prototype-less objects, and dates
 * Lambdas, first-class functions, closures, and recursion

--- a/docs/datatypes.md
+++ b/docs/datatypes.md
@@ -354,11 +354,11 @@ Ada
 36
 ```
 
-The fields of an existing object can be updated with `mut`, using dot notation on the left-hand side. Note that `mut` reassigns or updates an existing binding. It does not add new fields to an object.
+The fields of an existing object can be updated by assigning to them with dot notation on the left-hand side. This reassigns an existing field; it does not add new fields to an object. (The assignment may optionally be prefixed with the `mut` keyword — `mut user.age = 37` — which behaves identically; see [Variables](directives.md#variables-let-and-assignment).)
 
 ```
 {{- let user = obj(name: "Ada", age: 36) -}}
-{{- mut user.age = 37 -}}
+{{- user.age = 37 -}}
 {{user.age}}
 ```
 ```
@@ -397,7 +397,7 @@ Like arrays, objects are reference types. Assigning an object to a new variable 
 ```
 {{- let x = obj(a: 1, b: 2) -}}
 {{- let y = x -}}
-{{- mut y.a = 3 -}}
+{{- y.a = 3 -}}
 {{ y.a }} {{ x.a }}
 ```
 ```
@@ -464,7 +464,7 @@ Output:
 50
 ```
 
-A lambda body may declare local `let` or `mut` statements before its result expression, each followed by a comma.
+A lambda body may declare local variables with `let`, and reassign them, before its result expression, each statement followed by a comma. As elsewhere, a reassignment is a plain `name = expr` (the `mut` keyword is optional).
 
 ```
 {{- let hypotenuseSquared = (a, b) => let a2 = a * a, let b2 = b * b, a2 + b2 -}}

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -94,15 +94,15 @@ This {{ price }} is printed verbatim, and {{ this }} is not evaluated.
 
 Literal blocks may be nested; the matching `{{ /literal }}` closes the outermost block.
 
-## Variables: `let` and `mut`
+## Variables: `let` and assignment
 
-`let` declares and binds a new variable. `mut` reassigns an existing variable, or updates a field of an existing object via dot notation — it does not create new variables or add new object fields.
+`let` declares and binds a new variable. To reassign an existing variable, or update a field of an existing object via dot notation, assign to it directly with `=` — this does not create new variables or add new object fields.
 
 ```
 {{- let count = 1 -}}
 {{- let user = obj(name: "Ada", age: 36) -}}
-{{- mut count = count + 1 -}}
-{{- mut user.age = 37 -}}
+{{- count = count + 1 -}}
+{{- user.age = 37 -}}
 {{ count }}
 {{ user.name }} is {{ user.age }}
 ```
@@ -111,6 +111,10 @@ Output:
 2
 Ada is 37
 ```
+
+An assignment may optionally be prefixed with the `mut` keyword (`{{ mut count = count + 1 }}`), which behaves identically to the plain form above.
+
+> **Note:** The `mut` keyword is deprecated. It still works today and existing templates will continue to run, but it may be removed in a future version. Prefer plain assignment and avoid `mut` in new templates.
 
 See [data types](datatypes.md) for how each kind of value behaves (in particular, arrays and objects are reference types).
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -11,7 +11,7 @@ A few things apply to every built-in:
 * **Overloading by type.** Many names (`length`, `concat`, `contains`, `order`, `round`, `string`) have several overloads. Powwow picks the overload that best matches the types of the arguments you pass. Passing a type no overload accepts is an evaluation error.
 * **Optional arguments.** Some functions take trailing optional arguments with a default value (shown as `arg = default` below). They may be omitted.
 * **Errors, not nulls.** When a built-in cannot do its job — an out-of-bounds index, a missing field, an unparseable string — it raises an evaluation error rather than returning a null or empty value. Powwow has no null type. Where a result is uncertain, guard first (for example with `contains` before `get`).
-* **Immutability.** Functions return new values; they never mutate their arguments. (The `mut` directive is the only way to change a binding — see [data types](datatypes.md).)
+* **Immutability.** Functions return new values; they never mutate their arguments. (Assignment — `x = ...`, optionally written `mut x = ...` — is the only way to change a binding — see [data types](datatypes.md).)
 
 Sections:
 

--- a/grammar.md
+++ b/grammar.md
@@ -77,8 +77,10 @@ are {{* ignored *}}
 
 ```
 assignment ::= directive_start "let" identifier "=" expression directive_end ;
-mutation ::= directive_start "mut" identifier ["." identifier] "=" expression directive_end ;
+mutation ::= directive_start ["mut"] identifier ["." identifier] "=" expression directive_end ;
 ```
+
+The leading `mut` keyword in a mutation is optional; `{{ y = 2 }}` and `{{ mut y = 2 }}` are equivalent. `mut` is deprecated and may be removed in a future version — prefer the bare form.
 
 ```
 capture ::= capture_open template capture_close ;
@@ -90,8 +92,9 @@ capture_close ::= directive_start "/capture" directive_end ;
 
 ```
 {{ let x = 1 }}
+{{ y = 2 }}
+{{ z.a = 3 }}
 {{ mut y = 2 }}
-{{ mut z.a = 3 }}
 {{ capture foo }}the capture body is evaluated {{let x = 1}}{{x}} and the result is stored into the newly declared variable foo{{ /capture}}
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -37,12 +37,13 @@ Output: `Hello, Ada!`
 
 `{{ literal }} ... {{ /literal }}` — emits the body verbatim; directives inside are NOT interpreted. May be nested.
 
-## Variables: let / mut
+## Variables: let / assignment
 
 - `{{ let x = expr }}` declares and binds a new variable.
-- `{{ mut x = expr }}` reassigns an EXISTING variable.
-- `{{ mut obj.field = expr }}` updates an EXISTING field of an object (dot notation, one level).
-- `mut` does NOT create new variables or add new object fields — only `let` (variables) and `obj(...)` (fields) do.
+- `{{ x = expr }}` reassigns an EXISTING variable.
+- `{{ obj.field = expr }}` updates an EXISTING field of an object (dot notation, one level).
+- Assignment does NOT create new variables or add new object fields — only `let` (variables) and `obj(...)` (fields) do.
+- The `mut` keyword is OPTIONAL and DEPRECATED: `{{ mut x = expr }}` is identical to `{{ x = expr }}`. It still works (and existing templates keep running) but may be REMOVED in a future version — do not use `mut` in new templates; prefer plain assignment. The same applies inside lambda statement lists (`(() => let x = 1, x = 2, x)()`).
 
 ## Conditionals: if
 
@@ -162,7 +163,7 @@ Dataverse (only if host supplies a Dataverse service):
 
 1. Subscripts are type-specific: array subscripts need a whole-number index (`arr[0]`), object subscripts need a string key (`obj["k"]`). `arr["0"]` or `obj[0]` errors. `at(arr, i)` and `get(obj, "k")` are the function equivalents.
 2. Accessing a missing object field ERRORS. Guard with `contains(obj, "field")` first.
-3. `mut` only reassigns existing variables/fields; it cannot add a new field to an object or declare a new variable.
+3. Assignment (`x = ...`, or the optional legacy `mut x = ...`) only reassigns existing variables/fields; it cannot add a new field to an object or declare a new variable.
 4. Arrays and objects are reference types: `==` compares identity, not contents; copying a variable shares the same value (mutations are visible through both names).
 5. Strings that look like dates are still strings; convert with `datetime(...)` before using date functions.
 6. Booleans don't support `< <= > >=` (numbers only).

--- a/src/dotnet/Interpreter.Tests/InterpreterTests.cs
+++ b/src/dotnet/Interpreter.Tests/InterpreterTests.cs
@@ -407,26 +407,26 @@ namespace PowwowLang.Tests
         public void UriFunctions()
         {
             // Arrange
-            var template = @"{{ let uri = uri(""https://user:password@www.site.com:80/Home/Index.htm?q1=v1&q2=v2#FragmentName"") }}{{uri.AbsolutePath}}
-{{uri.AbsoluteUri}}
-{{uri.DnsSafeHost}}
-{{uri.Fragment}}
-{{uri.Host}}
-{{uri.IdnHost}}
-{{uri.IsAbsoluteUri}}
-{{uri.IsDefaultPort}}
-{{uri.IsFile}}
-{{uri.IsLoopback}}
-{{uri.IsUnc}}
-{{uri.LocalPath}}
-{{uri.OriginalString}}
-{{uri.PathAndQuery}}
-{{uri.Port}}
-{{uri.Query}}
-{{uri.Scheme}}
-{{join(uri.Segments, "", "")}}
-{{uri.UserEscaped}}
-{{uri.UserInfo}}";
+            var template = @"{{ let uriRes = uri(""https://user:password@www.site.com:80/Home/Index.htm?q1=v1&q2=v2#FragmentName"") }}{{uriRes.AbsolutePath}}
+{{uriRes.AbsoluteUri}}
+{{uriRes.DnsSafeHost}}
+{{uriRes.Fragment}}
+{{uriRes.Host}}
+{{uriRes.IdnHost}}
+{{uriRes.IsAbsoluteUri}}
+{{uriRes.IsDefaultPort}}
+{{uriRes.IsFile}}
+{{uriRes.IsLoopback}}
+{{uriRes.IsUnc}}
+{{uriRes.LocalPath}}
+{{uriRes.OriginalString}}
+{{uriRes.PathAndQuery}}
+{{uriRes.Port}}
+{{uriRes.Query}}
+{{uriRes.Scheme}}
+{{join(uriRes.Segments, "", "")}}
+{{uriRes.UserEscaped}}
+{{uriRes.UserInfo}}";
 
             // Act
             var result = _interpreter.Interpret(template, new ExpandoObject());
@@ -2772,7 +2772,7 @@ End";
         [Test]
         public void ParameterNameConflict_ThrowsException()
         {
-            var template = "{{ (a) => a = 1, a }}";
+            var template = "{{ (a) => let a = 1, a }}";
             Assert.Throws<TemplateParsingException>(() => _interpreter.Interpret(template, new ExpandoObject()),
                 "Variable name 'a' conflicts with parameter name");
         }
@@ -2782,7 +2782,7 @@ End";
         {
             var template = "{{ let x = 2 }}{{ (() => let x = 3, x)() }}";
             Assert.Throws<TemplateEvaluationException>(() => _interpreter.Interpret(template, new ExpandoObject()),
-                "Cannot define variable 'x' as it conflicts with an existing variable or field");
+                "Cannot define variable 'x' because it conflicts with an existing variable, field, or function");
         }
 
         [Test]
@@ -2790,7 +2790,7 @@ End";
         {
             var template = "{{ for x in [1,2,3] }}{{ (() => let x = 3, x)() }}{{ /for }}";
             Assert.Throws<TemplateEvaluationException>(() => _interpreter.Interpret(template, new ExpandoObject()),
-                "Cannot define variable 'x' as it conflicts with an existing variable or field");
+                "Cannot define variable 'x' because it conflicts with an existing variable, field, or function");
         }
 
         [Test]
@@ -2801,7 +2801,7 @@ End";
 
             var template = "{{ ((a) => let x = [\"foo\"], concat(a, x))([1]) }}";
             var exception = Assert.Throws<TemplateEvaluationException>(() => _interpreter.Interpret(template, data),
-                "Cannot define variable 'x' as it conflicts with an existing variable or field");
+                "Cannot define variable 'x' because it conflicts with an existing variable, field, or function");
         }
 
         [Test]
@@ -2812,7 +2812,7 @@ End";
 
             var template = "{{ let x = 3 }}";
             var exception = Assert.Throws<TemplateEvaluationException>(() => _interpreter.Interpret(template, data),
-                "Cannot define variable 'x' as it conflicts with an existing variable or field");
+                "Cannot define variable 'x' because it conflicts with an existing variable, field, or function");
         }
 
         [Test]
@@ -2823,7 +2823,7 @@ End";
 
             var template = "{{ for i in [1, 2] }}{{ let x = 3 }}{{ /for }}";
             var exception = Assert.Throws<TemplateEvaluationException>(() => _interpreter.Interpret(template, data),
-                "Cannot define variable 'x' as it conflicts with an existing variable or field");
+                "Cannot define variable 'x' because it conflicts with an existing variable, field, or function");
         }
 
         [Test]
@@ -2849,15 +2849,15 @@ End";
         [Test]
         public void FunctionNameConflict_ThrowsException()
         {
-            var template = "{{ (a) => length = 3, a * length }}";
+            var template = "{{ (a) => let length = 3, a * length }}";
             Assert.Throws<TemplateParsingException>(() => _interpreter.Interpret(template, new ExpandoObject()),
-                "Cannot define variable 'length' as it conflicts with an existing function");
+                "Cannot define variable 'length' because it conflicts with an existing variable, field, or function");
         }
 
         [Test]
         public void VariableReassignment_ThrowsException()
         {
-            var template = "{{ () => x = 1, x = 2, x }}";
+            var template = "{{ () => let x = 1, let x = 2, x }}";
             Assert.Throws<TemplateParsingException>(() => _interpreter.Interpret(template, new ExpandoObject()),
                 "Cannot reassign variable 'x' in lambda function");
         }
@@ -4750,12 +4750,15 @@ string";
         {
             // Arrange
             string template = @"{{ let x = 1 }}{{ x }}{{ mut x = 2 }} {{ x }}";
+            string template2 = @"{{ let x = 1 }}{{ x }}{{ x = 2 }} {{ x }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("1 2"));
+            Assert.That(result2, Is.EqualTo("1 2"));
         }
 
         [Test]
@@ -4763,12 +4766,17 @@ string";
         {
             // Arrange
             string template = @"{{ for x in [1, 2] }}{{ mut x = 3 }}{{ x }}{{ /for }}";
+            string template2 = @"{{ for x in [1, 2] }}{{ x = 3 }}{{ x }}{{ /for }}";
 
             var exception = Assert.Throws<TemplateEvaluationException>(() => {
                 _interpreter.Interpret(template, _emptyData);
             });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => {
+                _interpreter.Interpret(template2, _emptyData);
+            });
 
             StringAssert.Contains("Iterator variable x is not mutable and cannot be reassigned", exception.Message);
+            StringAssert.Contains("Iterator variable x is not mutable and cannot be reassigned", exception2.Message);
         }
 
         [Test]
@@ -4776,12 +4784,15 @@ string";
         {
             // Arrange
             string template = @"{{ let a = 0 }}{{ for x in [1, 2] }}{{ mut a = x }}{{ a }}{{ /for }}";
+            string template2 = @"{{ let a = 0 }}{{ for x in [1, 2] }}{{ a = x }}{{ a }}{{ /for }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("12"));
+            Assert.That(result2, Is.EqualTo("12"));
         }
 
 
@@ -4790,12 +4801,15 @@ string";
         {
             // Arrange
             string template = @"{{ let a = 0 }}{{ if false }}{{ mut a = ""foo"" }}{{ else }}{{ mut a = ""bar"" }}{{ /if }}{{ a }}";
+            string template2 = @"{{ let a = 0 }}{{ if false }}{{ a = ""foo"" }}{{ else }}{{ a = ""bar"" }}{{ /if }}{{ a }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("bar"));
+            Assert.That(result2, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -4803,13 +4817,18 @@ string";
         {
             // Arrange
             string template = @"{{ mut a = 0 }}";
+            string template2 = @"{{ a = 0 }}";
 
             // Act && Assert
             var exception = Assert.Throws<TemplateEvaluationException>(() => {
                 _interpreter.Interpret(template, _emptyData);
             });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => {
+                _interpreter.Interpret(template2, _emptyData);
+            });
 
             StringAssert.Contains("Cannot mutate variable 'a' because it has not been defined", exception.Message);
+            StringAssert.Contains("Cannot mutate variable 'a' because it has not been defined", exception2.Message);
         }
 
         [Test]
@@ -4817,6 +4836,7 @@ string";
         {
             // Arrange
             string template = @"{{ var2 }}{{ mut var2 = 10 }}";
+            string template2 = @"{{ var2 }}{{ var2 = 10 }}";
             var data = new ExpandoObject();
             ((IDictionary<string, object>)data).Add("var2", 2.5);
 
@@ -4824,8 +4844,12 @@ string";
             var exception = Assert.Throws<TemplateEvaluationException>(() => {
                 _interpreter.Interpret(template, data);
             });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => {
+                _interpreter.Interpret(template2, data);
+            });
 
             StringAssert.Contains("Global variable var2 is not mutable and cannot be reassigned", exception.Message);
+            StringAssert.Contains("Global variable var2 is not mutable and cannot be reassigned", exception2.Message);
         }
 
         [Test]
@@ -4833,12 +4857,15 @@ string";
         {
             // Arrange
             string template = @"{{ (() => let x = 1, mut x = 2, x)() }}";
+            string template2 = @"{{ (() => let x = 1, x = 2, x)() }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("2"));
+            Assert.That(result2, Is.EqualTo("2"));
         }
 
         [Test]
@@ -4846,6 +4873,7 @@ string";
         {
             // Arrange
             string template = @"{{ (() => let x = 1, mut var2 = 2, x)() }}";
+            string template2 = @"{{ (() => let x = 1, var2 = 2, x)() }}";
             var data = new ExpandoObject();
             ((IDictionary<string, object>)data).Add("var2", 2.5);
 
@@ -4853,8 +4881,12 @@ string";
             var exception = Assert.Throws<TemplateEvaluationException>(() => {
                 _interpreter.Interpret(template, data);
             });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => {
+                _interpreter.Interpret(template2, data);
+            });
 
             StringAssert.Contains("Global variable var2 is not mutable and cannot be reassigned", exception.Message);
+            StringAssert.Contains("Global variable var2 is not mutable and cannot be reassigned", exception2.Message);
         }
 
         [Test]
@@ -4862,13 +4894,18 @@ string";
         {
             // Arrange
             string template = @"{{ ((y) => let x = 1, mut y = 2, x * y)(1) }}";
+            string template2 = @"{{ ((y) => let x = 1, y = 2, x * y)(1) }}";
 
             // Act && Assert
             var exception = Assert.Throws<TemplateEvaluationException>(() => {
                 _interpreter.Interpret(template, _emptyData);
             });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => {
+                _interpreter.Interpret(template2, _emptyData);
+            });
 
             StringAssert.Contains("Parameter y is not mutable and cannot be reassigned", exception.Message);
+            StringAssert.Contains("Parameter y is not mutable and cannot be reassigned", exception2.Message);
         }
 
         [Test]
@@ -4889,13 +4926,18 @@ string";
         {
             // Arrange
             string template = @"{{ for y in [1, 2] }}{{ (() => let x = 2, mut y = 2, x * y)() }}{{ /for }}";
+            string template2 = @"{{ for y in [1, 2] }}{{ (() => let x = 2, y = 2, x * y)() }}{{ /for }}";
 
             // Act && Assert
             var exception = Assert.Throws<TemplateEvaluationException>(() => {
                 _interpreter.Interpret(template, _emptyData);
             });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => {
+                _interpreter.Interpret(template2, _emptyData);
+            });
 
             StringAssert.Contains("Iterator variable y is not mutable and cannot be reassigned", exception.Message);
+            StringAssert.Contains("Iterator variable y is not mutable and cannot be reassigned", exception2.Message);
         }
 
         [Test]
@@ -4903,13 +4945,18 @@ string";
         {
             // Arrange
             string template = @"{{ ((x) => (() => mut x = 2, x)())(1) }}";
+            string template2 = @"{{ ((x) => (() => x = 2, x)())(1) }}";
 
             // Act && Assert
             var exception = Assert.Throws<TemplateEvaluationException>(() => {
                 _interpreter.Interpret(template, _emptyData);
             });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => {
+                _interpreter.Interpret(template2, _emptyData);
+            });
 
             StringAssert.Contains("Parameter x is not mutable and cannot be reassigned", exception.Message);
+            StringAssert.Contains("Parameter x is not mutable and cannot be reassigned", exception2.Message);
         }
 
         [Test]
@@ -4917,12 +4964,15 @@ string";
         {
             // Arrange
             string template = @"{{ let z = 1 }}{{ (() => let x = 1, (() => mut z = 3, mut x = 2, x * z)())(1) }}";
+            string template2 = @"{{ let z = 1 }}{{ (() => let x = 1, (() => z = 3, x = 2, x * z)())(1) }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("6"));
+            Assert.That(result2, Is.EqualTo("6"));
         }
 
         [Test]
@@ -4933,14 +4983,14 @@ string";
 {{- let counter = (x) => 
    let self = (() => obj(
      current: x,
-     increment: () => mut self.current = self.current + 1, self.current
+     increment: () => self.current = self.current + 1, self.current
    ))(), 
    self 
 -}}
 {{- let c = counter(0) -}}
 {{- let _ = 0 -}}
 {{- for i in range(0, 10) -}}
-  {{- mut _ = c.increment() -}}
+  {{- _ = c.increment() -}}
 {{- /for -}}
 {{ c.current }}";
 
@@ -5000,12 +5050,15 @@ string";
         {
             // Arrange
             string template = @"{{ let x = 1 }}{{ let y = x }}{{ mut y = 2 }}{{ y }} {{ x }}";
+            string template2 = @"{{ let x = 1 }}{{ let y = x }}{{ y = 2 }}{{ y }} {{ x }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("2 1"));
+            Assert.That(result2, Is.EqualTo("2 1"));
         }
 
         [Test]
@@ -5013,12 +5066,15 @@ string";
         {
             // Arrange
             string template = @"{{ let x = ""abc"" }}{{ let y = x }}{{ mut y = ""def"" }}{{ y }} {{ x }}";
+            string template2 = @"{{ let x = ""abc"" }}{{ let y = x }}{{ y = ""def"" }}{{ y }} {{ x }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("def abc"));
+            Assert.That(result2, Is.EqualTo("def abc"));
         }
 
         [Test]
@@ -5026,12 +5082,15 @@ string";
         {
             // Arrange
             string template = @"{{ let x = false }}{{ let y = x }}{{ mut y = true }}{{ y }} {{ x }}";
+            string template2 = @"{{ let x = false }}{{ let y = x }}{{ y = true }}{{ y }} {{ x }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("true false"));
+            Assert.That(result2, Is.EqualTo("true false"));
         }
 
         [Test]
@@ -5039,12 +5098,15 @@ string";
         {
             // Arrange
             string template = @"{{ let x = Number }}{{ let y = x }}{{ mut y = String }}{{ y }} {{ x }}";
+            string template2 = @"{{ let x = Number }}{{ let y = x }}{{ y = String }}{{ y }} {{ x }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("type<String> type<Number>"));
+            Assert.That(result2, Is.EqualTo("type<String> type<Number>"));
         }
 
         [Test]
@@ -5052,12 +5114,15 @@ string";
         {
             // Arrange
             string template = @"{{ let x = obj(a: 1, b: 2) }}{{ let y = x }}{{ mut y.a = 3 }}{{ y.a }} {{ x.a }}";
+            string template2 = @"{{ let x = obj(a: 1, b: 2) }}{{ let y = x }}{{ y.a = 3 }}{{ y.a }} {{ x.a }}";
 
             // Act
             string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
 
             // Assert
             Assert.That(result, Is.EqualTo("3 3"));
+            Assert.That(result2, Is.EqualTo("3 3"));
         }
 
         [Test]
@@ -5233,6 +5298,37 @@ string";
             });
 
             StringAssert.Contains("Error at line 1, column 1: Object does not contain field 'age'", exception.Message);
+        }
+
+        [Test]
+        public void MutKeywordIsOptional()
+        {
+            // Arrange
+            string template = @"{{ let x = 1 }}{{ x = 2 }}{{ x }}";
+            string template2 = @"{{ (() => let x = 1, x = 2, x)() }}";
+
+            // Act
+            string result = _interpreter.Interpret(template, _emptyData);
+            string result2 = _interpreter.Interpret(template2, _emptyData);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("2"));
+            Assert.That(result2, Is.EqualTo("2"));
+        }
+
+        [Test]
+        public void CannotMutateExistingRegistryFunctionInLambda()
+        {
+            // Arrange
+            string template = @"{{ (() => let x = 1, length = 1, x)() }}";
+
+            // Act && Assert
+            var exception = Assert.Throws<TemplateEvaluationException>(() =>
+            {
+                _interpreter.Interpret(template, _emptyData);
+            });
+
+            StringAssert.Contains("Error at line 1, column 36: Cannot mutate variable 'length' because it is an existing function", exception.Message);
         }
     }
 }

--- a/src/dotnet/Interpreter/Ast/LambdaNode.cs
+++ b/src/dotnet/Interpreter/Ast/LambdaNode.cs
@@ -53,22 +53,12 @@ namespace PowwowLang.Ast
             {
                 if (statement.Value.Item2 == StatementType.Declaration)
                 {
-                    if (parameters.Contains(statement.Key))
+                    if (parameters.Contains(statement.Key) || 
+                        functionRegistry.HasFunction(statement.Key) ||
+                        !seenVariables.Add(statement.Key))
                     {
                         throw new TemplateParsingException(
-                            $"Cannot define variable '{statement.Key}' because it conflicts with an existing variable or field",
-                            location);
-                    }
-                    if (functionRegistry.HasFunction(statement.Key))
-                    {
-                        throw new TemplateParsingException(
-                            $"Cannot define variable '{statement.Key}' because it conflicts with an existing function",
-                            location);
-                    }
-                    if (!seenVariables.Add(statement.Key))
-                    {
-                        throw new TemplateParsingException(
-                            $"Cannot define variable '{statement.Key}' because it conflicts with an existing variable or field",
+                            $"Cannot define variable '{statement.Key}' because it conflicts with an existing variable, field, or function",
                             location);
                     }
                 }

--- a/src/dotnet/Interpreter/Env/ExecutionContext.cs
+++ b/src/dotnet/Interpreter/Env/ExecutionContext.cs
@@ -54,11 +54,14 @@ namespace PowwowLang.Env
 
         public virtual void DefineVariable(string name, Value value)
         {
-            // Check if already defined as a variable, an iterator variable, or defined in the data context
-            if (_variables.ContainsKey(name) || _iteratorValues.ContainsKey(name) || TryResolveValue(name, out _))
+            // Check if already defined as a variable, an iterator variable, function registry function, or defined in the data context
+            if (_variables.ContainsKey(name) ||
+                _iteratorValues.ContainsKey(name) ||
+                _functionRegistry.HasFunction(name) ||
+                TryResolveValue(name, out _))
             {
                 throw new InnerEvaluationException(
-                    $"Cannot define variable '{name}' because it conflicts with an existing variable or field");
+                    $"Cannot define variable '{name}' because it conflicts with an existing variable, field, or function");
             }
 
             // If we get here, the name is safe to use
@@ -67,6 +70,13 @@ namespace PowwowLang.Env
 
         public virtual void RedefineVariable(string name, Value value)
         {
+            var firstPart = name.Split('.')[0];
+            if (_functionRegistry.HasFunction(firstPart))
+            {
+                throw new InnerEvaluationException(
+                    $"Cannot mutate variable '{name}' because it is an existing function");
+            }
+
             bool result = TryResolveMutableValue(name, out Value variable);
             if (!result)
             {

--- a/src/dotnet/Interpreter/Env/LambdaExecutionContext.cs
+++ b/src/dotnet/Interpreter/Env/LambdaExecutionContext.cs
@@ -50,10 +50,10 @@ namespace PowwowLang.Env
         public override void DefineVariable(string name, Value value)
         {
             // Check if already defined as a variable
-            if (_variables.ContainsKey(name))
+            if (_variables.ContainsKey(name) || _parentContext.GetFunctionRegistry().HasFunction(name))
             {
                 throw new InnerEvaluationException(
-                    $"Cannot define variable '{name}' because it conflicts with an existing variable or field");
+                    $"Cannot define variable '{name}' because it conflicts with an existing variable, field, or function");
             }
 
             // Check if defined as a parameter
@@ -66,7 +66,7 @@ namespace PowwowLang.Env
             if (_parentContext.TryResolveNonShadowableValue(name, out _))
             {
                 throw new InnerEvaluationException(
-                    $"Cannot define variable '{name}' because it conflicts with an existing variable or field");
+                    $"Cannot define variable '{name}' because it conflicts with an existing variable, field, or function");
             }
 
             _variables[name] = value;

--- a/src/dotnet/Interpreter/Parse/Parser.cs
+++ b/src/dotnet/Interpreter/Parse/Parser.cs
@@ -84,6 +84,10 @@ namespace PowwowLang.Parse
                         {
                             nodes.Add(ParseMutationStatement());
                         }
+                        else if (nextToken.Type == TokenType.Variable && IsMutationAhead(_position + 1))
+                        {
+                            nodes.Add(ParseImplicitMutation());
+                        }
                         else if (nextToken.Type == TokenType.Capture)
                         {
                             nodes.Add(ParseCaptureStatement());
@@ -180,10 +184,24 @@ namespace PowwowLang.Parse
 
         private AstNode ParseMutationStatement()
         {
+            // Leaving support in for the mut keyword for backwards compatibility
             Advance(); // Skip {{
             var token = Current();
             Advance(); // Skip mut
 
+            return ParseMutationBase(token);
+        }
+
+        private AstNode ParseImplicitMutation()
+        {
+            Advance(); // Skip {{
+            var token = Current();
+
+            return ParseMutationBase(token);
+        }
+
+        private AstNode ParseMutationBase(Token token)
+        {
             var variableName = Expect(TokenType.Variable).Value;
             Advance();
 
@@ -412,7 +430,7 @@ namespace PowwowLang.Parse
             // Parse statement list
             while (true)
             {
-                if (Current().Type != TokenType.Let && Current().Type != TokenType.Mutation)
+                if (Current().Type != TokenType.Let && Current().Type != TokenType.Mutation && !IsMutationAhead(_position))
                 {
                     // If next expression is not a variable declaration or mutation then must be return statement
                     var finalExpression = ParseExpression();
@@ -420,7 +438,10 @@ namespace PowwowLang.Parse
                 }
 
                 var statementType = Current().Type == TokenType.Let ? LambdaNode.StatementType.Declaration : LambdaNode.StatementType.Mutation;
-                Advance(); // skip let or mut
+                if (Current().Type == TokenType.Let || Current().Type == TokenType.Mutation)
+                {
+                    Advance(); // skip let or mut if it's not an implicit mutation
+                }
 
                 string variableName = null;
                 try
@@ -432,7 +453,7 @@ namespace PowwowLang.Parse
                 catch (TemplateParsingException ex)
                 {
                     throw new TemplateParsingException(
-                        $"Expected variable name after 'let' or 'mut' in lambda: {ex.Descriptor}",
+                        $"Expected variable name in lambda: {ex.Descriptor}",
                         Current().Location
                     );
                 }
@@ -1020,6 +1041,29 @@ namespace PowwowLang.Parse
                     throw new TemplateParsingException($"Unable to parse unknown type {token.Value}", token.Location);
             }
             return new TypeNode(type, token.Location);
+        }
+
+        private bool IsMutationAhead(int pos)
+        {
+            if (pos >= _tokens.Count || _tokens[pos].Type != TokenType.Variable)
+            {
+                return false;
+            }
+
+            pos++; // Skip Variable
+
+            while (pos < _tokens.Count && _tokens[pos].Type == TokenType.Dot)
+            {
+                pos++; // Skip Dot
+                if (pos >= _tokens.Count || 
+                    (_tokens[pos].Type != TokenType.Field && _tokens[pos].Type != TokenType.Variable))
+                {
+                    return false;
+                }
+                pos++; // Skip Field
+            }
+
+            return pos < _tokens.Count && _tokens[pos].Type == TokenType.Assignment;
         }
 
         private bool IsLambdaAhead()


### PR DESCRIPTION
* Makes the `mut` keyword optional (may be removed in future)
* Registered functions names can no longer be reassigned