### PR TITLE
adjusted scoping rules and documented; defaulted midpoint rounding to awayfromzero

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You can extend the language for your host:
 * [Data types](docs/datatypes.md) — numbers, strings, booleans, arrays, objects, and dates
 * [Operators](docs/operators.md) — arithmetic, comparison, logical, and unary operators
 * [Template syntax and directives](docs/directives.md) — directives, whitespace control, conditionals, loops, capture, and composition
+* [Scoping and mutability](docs/scoping.md) — scope and name resolution, closures, and which bindings can be reassigned
 * [Built-in functions](docs/functions.md) — the full function reference
 * [Embedding](docs/embedding.md) — host integration: data binding, custom functions, composition, and Dataverse
 * [Grammar](grammar.md) — the formal language grammar

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -139,6 +139,8 @@ Output:
 C
 ```
 
+Each branch is **block-scoped**: a variable declared with `let` inside a branch is local to that branch and is not visible after the `if`. Reassigning a variable that was declared outside the `if` does persist, however. Because Powwow has no "declare without value" form, the way to set a value conditionally for later use is to declare it with a default before the `if` and reassign it inside a branch — see [Setting a variable conditionally](scoping.md#setting-a-variable-conditionally).
+
 For an inline conditional *expression* (rather than a block), see the [`if(...)` function](functions.md#control-flow-functions).
 
 ## Loops: `for`
@@ -179,6 +181,8 @@ Hello, Ada!
 
 The captured value is the rendered text of the body, so a capture can contain any directives — including loops, conditionals, and `include` — and the variable it produces is an ordinary string.
 
+The body is **block-scoped**: only the capture variable is published to the surrounding scope. Any `let` used inside the body to help build the string is local to it and is not visible afterward. See [Scoping and mutability](scoping.md#what-creates-a-new-scope).
+
 ## Composition: `include`
 
 `include` renders another template inline by name, which lets you factor shared pieces (headers, footers, partials) into their own templates and compose them.
@@ -189,4 +193,6 @@ The captured value is the rendered text of the body, so a capture can contain an
 {{ include footer }}
 ```
 
-Includes are resolved by the host through an `ITemplateResolver` that maps a name (`header`, `footer`, …) to template source. If the interpreter was created without a resolver, `include` is unavailable. The included template is rendered with access to the same data and functions as its host, and **circular includes are detected and reported** as an error rather than looping forever. See [Embedding Powwow in a .NET host](embedding.md#template-composition) for wiring up a resolver.
+Includes are resolved by the host through an `ITemplateResolver` that maps a name (`header`, `footer`, …) to template source. If the interpreter was created without a resolver, `include` is unavailable. **Circular includes are detected and reported** as an error rather than looping forever. See [Embedding Powwow in a .NET host](embedding.md#template-composition) for wiring up a resolver.
+
+The included template is **block-scoped**: it runs in its own scope, so any variable it declares with `let` at the top level is local to it and is not visible to the including template — an `include` publishes nothing back to its caller and contributes only rendered text. It can still read names that are in scope at the include site, as well as host data and registered functions. See [Scoping and mutability](scoping.md#what-creates-a-new-scope).

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -122,7 +122,7 @@ string output = interpreter.Interpret(
 // <h1>My Page</h1><main>Hello World</main><footer>© 2025</footer>
 ```
 
-Included templates render with access to the same data and functions as the template that includes them, and they may include further templates. **Circular includes are detected** and raise a parsing error rather than looping forever. To resolve templates from elsewhere — a database, the file system, Dataverse — implement `ITemplateResolver` yourself; the only requirement is to return template source for a name (or throw if it is unknown).
+Included templates are block-scoped: they render with access to the data, functions, and variables in scope where they are included, but any variable they declare with `let` stays local and is not visible back in the including template — an include contributes rendered text only (see [Scoping and mutability](scoping.md#what-creates-a-new-scope)). They may include further templates. **Circular includes are detected** and raise a parsing error rather than looping forever. To resolve templates from elsewhere — a database, the file system, Dataverse — implement `ITemplateResolver` yourself; the only requirement is to return template source for a name (or throw if it is unknown).
 
 ## Dataverse integration
 

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -1,0 +1,311 @@
+# Scoping and mutability
+
+This document describes how Powwow resolves variable names, which constructs introduce a new scope, which bindings can and cannot be reassigned, and how lambdas capture their surrounding scope to form closures.
+
+Powwow uses **lexical scoping**: a name is resolved by looking outward through the scopes that textually enclose its use, ending at the global scope. There is no dynamic scoping of ordinary variables — a lambda sees the variables where it was *defined*, not where it was *called* (see [Closures](#closures)).
+
+## The global scope
+
+Every template runs inside a single outermost scope, the **global scope**. It contains three kinds of names:
+
+* **Host data.** The data object passed in by the host application. Its properties are referenced as top-level names (and nested properties with dot notation). These are read-only — see [Mutable and immutable bindings](#mutable-and-immutable-bindings).
+* **Registered functions.** All built-in functions (`length`, `map`, `format`, …) and any custom functions the host registers. See [Embedding](embedding.md) for registration.
+* **Top-level variables.** Anything declared with `let` directly in the template body.
+
+## Name resolution
+
+When a name is used, Powwow searches scopes from the innermost outward and the **first match wins**:
+
+1. The **current scope** — for a lambda call, its parameters and any locals declared with `let`; for a loop iteration, the loop variable and any locals; for an `if` branch or `capture` body, its locals; for the template body, the top-level variables.
+2. **Enclosing scopes**, following the chain outward. For a lambda this means its *definition* (closure) scope, then the scope of its *caller*.
+3. The **global scope** — host data, then registered functions.
+
+If no scope contains the name, evaluation fails:
+
+```
+{{ doesNotExist }}
+```
+```
+Output:
+(evaluation error: Unknown identifier: doesNotExist)
+```
+
+A lambda can freely read names from the scope that encloses it:
+
+```
+{{- let x = 2 -}}
+{{ ((a) => a * x)(3) }}
+```
+```
+Output:
+6
+```
+
+## What creates a new scope
+
+Every construct with a body runs that body in a fresh scope. A new scope is created by:
+
+* **Each call to a lambda** — holds the parameters and any locals the body declares.
+* **Each iteration of a `for` loop** — holds the loop variable and any locals declared in the body.
+* **Each branch of an `if`** — the `if`, `elseif`, or `else` body that runs does so in its own scope.
+* **The body of a `capture`** — runs in its own scope; only the capture variable itself is published to the enclosing scope (that variable is the block's single, explicit output).
+* **An included template** — the body pulled in by `include` runs in its own scope. Unlike `capture`, an `include` publishes *nothing* back to its caller; it contributes only rendered text. Its top-level `let`s are local to it and are not visible to the including template, though it can still read the names in scope at the include site along with host data and registered functions.
+
+Only the root template body runs directly in the [global scope](#the-global-scope).
+
+All of these scopes behave the same way:
+
+* A `let` inside the body is **local** and is discarded when the body finishes. It does not leak out, and (for loops) does not carry across iterations.
+* The body can still **read and reassign** names from enclosing scopes. A reassignment reaches the outer binding and persists after the block ends.
+* A `let` inside the body may **not reuse a name** that is already visible further out. Powwow's block scopes prevent leakage but do **not** allow shadowing: spelling an inner `let` with an outer name is an error, not a new inner variable. (Lambda parameters are the sole exception — a parameter may reuse an outer name and takes precedence inside the lambda.)
+
+So a `let` declared inside an `if` branch is not visible once the block ends:
+
+```
+{{- let x = 1 -}}
+{{- if x == 1 -}}{{- let z = 2 -}}{{- /if -}}
+{{ z }}
+```
+```
+Output:
+(evaluation error: Unknown identifier: z)
+```
+
+Reassigning a variable from an enclosing scope, on the other hand, works and persists, because assignment resolves outward along the scope chain. Both the `if` and the `for` below update a variable declared outside them:
+
+```
+{{- let x = 1 -}}
+{{- if x == 1 -}}{{- x = 2 -}}{{- /if -}}
+{{ x }}
+```
+```
+Output:
+2
+```
+
+```
+{{- let total = 0 -}}
+{{- for n in [1, 2, 3] -}}
+{{- total = total + n -}}
+{{- /for -}}
+{{ total }}
+```
+```
+Output:
+6
+```
+
+## Setting a variable conditionally
+
+Powwow has no "declare without value" form: every `let` must bind a value immediately. Combined with block scoping, this means you cannot declare a variable inside an `if` branch and read it after the block. The pattern is to **declare the variable with a sensible default in the enclosing scope, then reassign it inside the branch** — the reassignment reaches the outer binding:
+
+```
+{{- let plan = obj(premium: true) -}}
+{{- let label = "Free" -}}
+{{- if plan.premium -}}{{- label = "Premium" -}}{{- /if -}}
+{{ label }}
+```
+```
+Output:
+Premium
+```
+
+For a straightforward either/or value, the [`if(cond, a, b)` function](functions.md#control-flow-functions) is more direct, because it is an expression and can be bound in a single `let`:
+
+```
+{{- let plan = obj(premium: true) -}}
+{{- let label = if(plan.premium, "Premium", "Free") -}}
+{{ label }}
+```
+```
+Output:
+Premium
+```
+
+When the value you want is rendered text, `capture` is the idiomatic choice, since its variable is published to the enclosing scope by design:
+
+```
+{{- let plan = obj(premium: true) -}}
+{{- capture label -}}{{- if plan.premium -}}Premium{{- else -}}Free{{- /if -}}{{- /capture -}}
+{{ label }}
+```
+```
+Output:
+Premium
+```
+
+## Declaring and reassigning variables
+
+`let` **declares** a new variable; it binds a name for the first time. A plain assignment (`name = expr`, optionally written `mut name = expr`) **reassigns** a name that already exists. See [Variables](directives.md#variables-let-and-assignment) for the directive syntax.
+
+A name may be declared only once per scope, and `let` cannot reuse a name that is already visible — there is **no shadowing**. Declaring a name that already exists as a variable, a loop variable, a host data property, or a registered function is an error:
+
+```
+{{- let x = 1 -}}
+{{- let x = 2 -}}
+```
+```
+Output:
+(evaluation error: Cannot define variable 'x' because it conflicts with an existing variable, field, or function)
+```
+
+The restriction runs both ways between variables and loop variables: a loop variable may not reuse the name of a variable in scope, and a `let` inside a loop may not reuse the loop variable's name.
+
+```
+{{- let item = 5 -}}
+{{- for item in [1, 2, 3] -}}{{ item }}{{ /for -}}
+```
+```
+Output:
+(evaluation error: Iterator name 'item' conflicts with an existing variable, field, or function)
+```
+
+To change a value, declare it once with `let` and then reassign it — provided the binding is mutable, as described next.
+
+## Mutable and immutable bindings
+
+Only some kinds of bindings can be reassigned. Attempting to reassign anything else is an evaluation error.
+
+### Mutable
+
+* **Variables declared with `let`**, whether at the top level or inside a lambda body.
+
+  ```
+  {{- let count = 1 -}}
+  {{- count = count + 1 -}}
+  {{ count }}
+  ```
+  ```
+  Output:
+  2
+  ```
+
+* **Fields of an object** held in a `let` variable, addressed with dot notation. This updates an existing field; it does not add new fields.
+
+  ```
+  {{- let user = obj(name: "Ada", age: 36) -}}
+  {{- user.age = 37 -}}
+  {{ user.age }}
+  ```
+  ```
+  Output:
+  37
+  ```
+
+### Immutable
+
+The following can be read but never reassigned:
+
+* **Loop variables.** The variable bound by `for ... in` is fixed for the duration of each iteration.
+
+  ```
+  {{- for n in [1, 2, 3] -}}{{- n = n + 1 -}}{{- /for -}}
+  ```
+  ```
+  Output:
+  (evaluation error: Iterator variable n is not mutable and cannot be reassigned)
+  ```
+
+* **Lambda parameters.** A parameter is bound to its argument for the call and cannot be reassigned (declare a local `let` if you need a mutable copy).
+
+  ```
+  {{ ((y) => let x = 1, y = 2, x * y)(1) }}
+  ```
+  ```
+  Output:
+  (evaluation error: Parameter y is not mutable and cannot be reassigned)
+  ```
+
+* **Host data (global variables).** Properties supplied by the host are read-only.
+
+  ```
+  {{* assuming the host provided a data field named "name" *}}
+  {{ name = "Bob" }}
+  ```
+  ```
+  Output:
+  (evaluation error: Global variable name is not mutable and cannot be reassigned)
+  ```
+
+* **Registered functions.** A built-in or host-registered function name cannot be reassigned, nor declared as a variable.
+
+  ```
+  {{ length = 3 }}
+  ```
+  ```
+  Output:
+  (evaluation error: Cannot mutate variable 'length' because it is an existing function)
+  ```
+
+### Value copies versus shared references
+
+Reassigning a variable that holds a `Number`, `String`, `Boolean`, or type literal replaces that variable's own value and affects nothing else, because these values are copied when bound. Arrays, objects, and functions are reference types: binding one to a second variable makes both names refer to the same underlying value, so a field update through one name is visible through the other. This distinction is covered in detail in the [data types](datatypes.md#array) reference and matters whenever a value is shared across scopes (including by a closure).
+
+## Closures
+
+A lambda is a **closure**: when its literal is evaluated, it captures the scope in which it was defined. Calling it later creates a fresh call scope whose enclosing scope is that captured definition scope. Free names in the body are resolved against the definition scope first, then against the caller's scope, and finally the global scope.
+
+Because capture is by reference to the binding (not a snapshot of the value), a closure sees later changes to a captured variable, and several closures sharing a binding share its state:
+
+```
+{{- let x = 2 -}}
+{{- let getX = () => x -}}
+{{- x = 5 -}}
+{{ getX() }}
+```
+```
+Output:
+5
+```
+
+This makes it possible to build stateful objects whose methods mutate a shared, captured field. Here each call to `increment` updates the same `self.current`:
+
+```
+{{- let counter = (x) =>
+   let self = (() => obj(
+     current: x,
+     increment: () => self.current = self.current + 1, self.current
+   ))(),
+   self
+-}}
+{{- let c = counter(0) -}}
+{{- let _ = 0 -}}
+{{- for i in range(0, 10) -}}
+  {{- _ = c.increment() -}}
+{{- /for -}}
+{{ c.current }}
+```
+```
+Output:
+10
+```
+
+Because a lambda resolves its own name through its definition scope at call time, a lambda can call itself recursively, and two lambdas defined next to each other can call each other (mutual recursion) even though each name is only declared after the other:
+
+```
+{{- let fact = (n) => if(n <= 1, 1, n * fact(n - 1)) -}}
+{{ fact(5) }}
+```
+```
+Output:
+120
+```
+
+```
+{{- let isEven = (n) => if(n == 0, true, isOdd(n - 1)) -}}
+{{- let isOdd = (n) => if(n == 0, false, isEven(n - 1)) -}}
+{{ isEven(10) }}
+```
+```
+Output:
+true
+```
+
+Recursion is bounded by a maximum call-stack depth (1000 by default, configurable by the host); exceeding it raises an evaluation error rather than overflowing the host stack.
+
+## Also see
+
+* [Template syntax and directives](directives.md) — the `let`, assignment, `for`, and `capture` directives
+* [Data types](datatypes.md) — value-copy versus reference semantics for each type
+* [Built-in functions](functions.md) — the registered functions that occupy the global scope
+* [Embedding](embedding.md) — supplying host data and registering custom functions

--- a/llms.txt
+++ b/llms.txt
@@ -50,7 +50,7 @@ Output: `Hello, Ada!`
 ```
 {{ if cond }} ... {{ elseif cond2 }} ... {{ else }} ... {{ /if }}
 ```
-The condition must be a boolean expression. `elseif`/`else` are optional. There is also a functional inline form: the `if(cond, then, else)` built-in (returns a value; both branches lazy).
+The condition must be a boolean expression. `elseif`/`else` are optional. There is also a functional inline form: the `if(cond, then, else)` built-in (returns a value; both branches lazy). Each branch is BLOCK-SCOPED: a `let` inside a branch does not leak out (see Scoping).
 
 ## Loops: for
 
@@ -64,11 +64,23 @@ Iterates an array, binding each element to the loop variable. Pairs with `range(
 ```
 {{ capture name }} ...body... {{ /capture }}
 ```
-Evaluates the body, stores the RENDERED STRING into a new variable `name`, and emits nothing at the site. Body may contain any directives (loops, if, include).
+Evaluates the body, stores the RENDERED STRING into a new variable `name`, and emits nothing at the site. Body may contain any directives (loops, if, include). The body is BLOCK-SCOPED: only `name` is published to the surrounding scope; `let`s used inside the body are local to it (see Scoping).
 
 ## Composition: include
 
-`{{ include templateName }}` renders another template inline by bare name. Requires the host to supply an `ITemplateResolver`; otherwise unavailable. Included templates share the host's data and functions. Circular includes are detected and error.
+`{{ include templateName }}` renders another template inline by bare name. Requires the host to supply an `ITemplateResolver`; otherwise unavailable. Included templates are BLOCK-SCOPED: they run in their own scope and can read the names in scope at the include site plus host data and functions, but their top-level `let`s do NOT leak back to the caller — an include publishes nothing back, only rendered text (see Scoping). Circular includes are detected and error.
+
+## Scoping
+
+Lexical scoping. A NEW scope is created by: a lambda call, each `for` iteration, each `if`/`elseif`/`else` branch, each `capture` body, and each `include` (the included template runs in its own scope). The root template body is the global scope (host data + registered functions).
+
+- A `let` inside a scope is LOCAL and discarded when the block ends — it does NOT leak out. So a `let` declared in an `if`/`capture`/`for` body is invisible afterward (`Unknown identifier`).
+- NO SHADOWING: an inner `let` may not reuse a name visible in an enclosing scope (it errors, it does not shadow). Exception: lambda parameters may reuse an outer name and take precedence inside the lambda.
+- Reassigning an OUTER variable from inside a scope (`x = ...`) reaches the outer binding and persists after the block.
+- A `capture` publishes only its variable to the enclosing scope; an `include` publishes nothing back (it emits rendered text only).
+- Resolution order: current scope -> enclosing scopes (for a lambda: its definition/closure scope, then the caller) -> global data -> registered functions. Unresolved name errors.
+- IMMUTABLE (reassignment errors): loop variables, lambda parameters, host/global data, registered functions. MUTABLE: `let` variables and the fields of objects they hold.
+- No "declare without value". To set a variable conditionally: declare it with a default first, then reassign inside the branch — `{{ let x = "Free" }}{{ if cond }}{{ x = "Premium" }}{{ /if }}` — or use the expression form `{{ let x = if(cond, "Premium", "Free") }}`, or `capture`.
 
 ## Data types
 
@@ -171,6 +183,7 @@ Dataverse (only if host supplies a Dataverse service):
 8. Decimal scale shows through: division and decimal literals can render trailing decimals (e.g. `4.0`). Use `round(x, n)` to control display.
 9. Whitespace around no-output directives (`let`, `for`, `if`) stays in the output unless you use `{{-`/`-}}`.
 10. `range`/`rangeX` ends are EXCLUSIVE.
+11. `if`/`elseif`/`else` branches, `capture` bodies, and included templates are BLOCK-SCOPED: a `let` inside does not survive the block (for an include, does not leak back to the caller), and cannot shadow an outer name. To compute a value conditionally, declare it with a default before the block and reassign inside (`{{ let x = "Free" }}{{ if c }}{{ x = "Premium" }}{{ /if }}`), or use `{{ let x = if(c, a, b) }}`. Reassigning an outer variable from inside a block does persist.
 
 ## Worked examples
 

--- a/src/dotnet/Interpreter.Tests/InterpreterTests.cs
+++ b/src/dotnet/Interpreter.Tests/InterpreterTests.cs
@@ -5330,5 +5330,102 @@ string";
 
             StringAssert.Contains("Error at line 1, column 36: Cannot mutate variable 'length' because it is an existing function", exception.Message);
         }
+
+        [Test]
+        public void CaptureIsBlockScoped()
+        {
+            // Arrange
+            string template = @"{{ let x =  1 }}{{ capture y }}{{ let z = 2 }}{{ z }}{{ /capture }}{{ z }}";
+
+            // Act && Assert
+            var exception = Assert.Throws<TemplateEvaluationException>(() =>
+            {
+                _interpreter.Interpret(template, _emptyData);
+            });
+
+            // Assert
+            StringAssert.Contains("Error at line 1, column 1: Unknown identifier: z", exception.Message);
+        }
+
+        [Test]
+        public void CaptureDoesntAllowShadowing()
+        {
+            // Arrange
+            string template = @"{{ let x =  1 }}{{ capture y }}{{ let x = 2 }}{{ /capture }}{{ x }}";
+
+            // Act && Assert
+            var exception = Assert.Throws<TemplateEvaluationException>(() =>
+            {
+                _interpreter.Interpret(template, _emptyData);
+            });
+
+            // Assert
+            StringAssert.Contains("Error at line 1, column 20: Cannot define variable 'x' because it conflicts with an existing variable, field, or function", exception.Message);
+        }
+
+        [Test]
+        public void IfIsBlockScoped()
+        {
+
+            // Arrange
+            string template = @"{{ let x = 1 }}{{ if x == 1 }}{{ let z = 2 }}{{ /if }}{{ z }}";
+            string template2 = @"{{ let x = 1 }}{{ if x == 2 }}{{ let z = 2 }}{{ elseif x == 1 }}{{ let z = 1 }}{{ /if }}{{ z }}";
+            string template3 = @"{{ let x = 1 }}{{ if x == 2 }}{{ let z = 2 }}{{ else }}{{ let z = 1 }}{{ /if }}{{ z }}";
+
+            // Act && Assert
+            var exception = Assert.Throws<TemplateEvaluationException>(() => { _interpreter.Interpret(template, _emptyData); });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => { _interpreter.Interpret(template2, _emptyData); });
+            var exception3 = Assert.Throws<TemplateEvaluationException>(() => { _interpreter.Interpret(template3, _emptyData); });
+
+            // Assert
+            StringAssert.Contains("Error at line 1, column 1: Unknown identifier: z", exception.Message);
+            StringAssert.Contains("Error at line 1, column 1: Unknown identifier: z", exception2.Message);
+            StringAssert.Contains("Error at line 1, column 1: Unknown identifier: z", exception3.Message);
+        }
+
+        [Test]
+        public void IfDoesntAllowShadowing()
+        {
+            // Arrange
+            string template = @"{{ let x = 1 }}{{ if x == 1 }}{{ let x = 2 }}{{ /if }}";
+            string template2 = @"{{ let x = 1 }}{{ if x == 2 }}{{ let x = 2 }}{{ elseif x == 1 }}{{ let x = 3 }}{{ /if }}";
+            string template3 = @"{{ let x = 1 }}{{ if x == 2 }}{{ let z = 2 }}{{ else }}{{ let x = 3 }}{{ /if }}";
+
+            // Act && Assert
+            var exception = Assert.Throws<TemplateEvaluationException>(() => { _interpreter.Interpret(template, _emptyData); });
+            var exception2 = Assert.Throws<TemplateEvaluationException>(() => { _interpreter.Interpret(template2, _emptyData); });
+            var exception3 = Assert.Throws<TemplateEvaluationException>(() => { _interpreter.Interpret(template3, _emptyData); });
+
+            // Assert
+            StringAssert.Contains("Error at line 1, column 19: Cannot define variable 'x' because it conflicts with an existing variable, field, or function", exception.Message);
+            StringAssert.Contains("Error at line 1, column 19: Cannot define variable 'x' because it conflicts with an existing variable, field, or function", exception2.Message);
+            StringAssert.Contains("Error at line 1, column 19: Cannot define variable 'x' because it conflicts with an existing variable, field, or function", exception3.Message);
+        }
+
+        [Test]
+        public void IfAllowsReassignmentOfOuterScopedLets()
+        {
+            // Arrange
+            string template = @"{{ let x = 1 }}{{ if x == 1 }}{{ x = 2 }}{{ /if }}{{ x }}";
+
+            // Act
+            string result = _interpreter.Interpret(template, _emptyData);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("2"));
+        }
+
+        [Test]
+        public void IteratorVariableCannotShadowFunctionNames()
+        {
+            // Arrange
+            string template = @"{{ for length in [1, 2] }}{{ length }}{{ /for }}";
+
+            // Act
+            var exception = Assert.Throws<TemplateEvaluationException>(() => { _interpreter.Interpret(template, _emptyData); });
+
+            // Assert
+            StringAssert.Contains("Error at line 1, column 1: Iterator name 'length' conflicts with an existing variable, field, or function", exception.Message);
+        }
     }
 }

--- a/src/dotnet/Interpreter/Ast/CaptureNode.cs
+++ b/src/dotnet/Interpreter/Ast/CaptureNode.cs
@@ -22,7 +22,13 @@ namespace PowwowLang.Ast
 
         public override Value Evaluate(ExecutionContext context)
         {
-            var result = _body.Evaluate(context);
+            var currentContext = new ExecutionContext(
+                context.GetData(),
+                context.GetFunctionRegistry(),
+                context,
+                context.MaxDepth,
+                this);
+            var result = _body.Evaluate(currentContext);
             try
             {
                 context.DefineVariable(_variableName, result);

--- a/src/dotnet/Interpreter/Ast/ForNode.cs
+++ b/src/dotnet/Interpreter/Ast/ForNode.cs
@@ -28,10 +28,10 @@ namespace PowwowLang.Ast
         public override Value Evaluate(ExecutionContext context)
         {
             // Check if iterator name conflicts with existing variable
-            if (context.TryResolveValue(_iteratorName, out _))
+            if (context.GetFunctionRegistry().HasFunction(_iteratorName) || context.TryResolveValue(_iteratorName, out _))
             {
                 throw new TemplateEvaluationException(
-                    $"Iterator name '{_iteratorName}' conflicts with an existing variable or field",
+                    $"Iterator name '{_iteratorName}' conflicts with an existing variable, field, or function",
                     context,
                     this);
             }

--- a/src/dotnet/Interpreter/Ast/IfNode.cs
+++ b/src/dotnet/Interpreter/Ast/IfNode.cs
@@ -40,13 +40,25 @@ namespace PowwowLang.Ast
                 var evaluated = branch.Condition.Evaluate(context);
                 if (TypeHelper.UnboxBoolean(evaluated, context, this))
                 {
-                    return branch.Body.Evaluate(context);
+                    var currentContext = new ExecutionContext(
+                        context.GetData(),
+                        context.GetFunctionRegistry(),
+                        context,
+                        context.MaxDepth,
+                        this);
+                    return branch.Body.Evaluate(currentContext);
                 }
             }
 
             if (_elseBranch != null)
             {
-                return _elseBranch.Evaluate(context);
+                var currentContext = new ExecutionContext(
+                    context.GetData(),
+                    context.GetFunctionRegistry(),
+                    context,
+                    context.MaxDepth,
+                    this);
+                return _elseBranch.Evaluate(currentContext);
             }
 
             return new Value(new StringValue(string.Empty));

--- a/src/dotnet/Interpreter/Lib/FunctionRegistry.cs
+++ b/src/dotnet/Interpreter/Lib/FunctionRegistry.cs
@@ -1188,7 +1188,7 @@ namespace PowwowLang.Lib
                 (context, callSite, args) =>
                 {
                     var number = (args[0].ValueOf() as NumberValue).Value();
-                    return new Value(new NumberValue(Math.Round(number, 0)));
+                    return new Value(new NumberValue(Math.Round(number, 0, MidpointRounding.AwayFromZero)));
                 });
 
             Register("round",


### PR DESCRIPTION
* Midpoint rounding on round function now defaults to awayfromzero
* If statement is now blocked scoped
* Capture statement is now block scoped
* Fixed issue where iterator name could shadow a registry function name