### PR TITLE
making default midpoint rounding away from zero and coercing null-named lookups to empty string for dataverse lookups

### DIFF
--- a/src/dotnet/Interpreter/Lib/DataverseService.cs
+++ b/src/dotnet/Interpreter/Lib/DataverseService.cs
@@ -60,7 +60,7 @@ namespace PowwowLang.Lib
                     return new Value(new ObjectValue(new Dictionary<string, Value>()
                     {
                         { "id", new Value(new StringValue(entityRef.Id.ToString())) },
-                        { "name", new Value(new StringValue(entityRef.Name)) },
+                        { "name", new Value(new StringValue(entityRef.Name ?? "")) },
                         { "logicalName", new Value(new StringValue(entityRef.LogicalName)) }
                     }));
 

--- a/src/dotnet/Interpreter/Lib/FunctionRegistry.cs
+++ b/src/dotnet/Interpreter/Lib/FunctionRegistry.cs
@@ -1209,7 +1209,7 @@ namespace PowwowLang.Lib
                             callSite);
                     }
 
-                    return new Value(new NumberValue(Math.Round(number, decimals)));
+                    return new Value(new NumberValue(Math.Round(number, decimals, MidpointRounding.AwayFromZero)));
                 });
 
             Register("string",


### PR DESCRIPTION
* Both `round` functions use MidpointRounding.AwayFromZero
* Dataverse results retrieve where the lookup has a null name is coerced into an empty string 